### PR TITLE
ci: 修复版本释放签名异常问题

### DIFF
--- a/.github/workflows/PreRelease.yaml
+++ b/.github/workflows/PreRelease.yaml
@@ -52,6 +52,7 @@ jobs:
         uses: Tlaster/android-sign@v1.2.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUILD_TOOLS_VERSION: "34.0.0"
           TZ: Asia/Shanghai
         with:
           # The directory to find your release to sign

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -53,6 +53,7 @@ jobs:
         uses: Tlaster/android-sign@v1.2.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUILD_TOOLS_VERSION: "34.0.0"
           TZ: Asia/Shanghai
         with:
           # The directory to find your release to sign


### PR DESCRIPTION
Thanks for submitting a pull request. Please include the following information.

**What I have done and why**
**ubuntu-latest** 虚拟机中不存在 **Tlaster/android-sign** 默认配置的 build tools `30.0.0` 版本，添加配置指定为存在的版本`34.0.0`

**Do tests pass?**
- [x] Run local tests on `OnlineDebug` and `OfflineDebug` variant: `./gradlew testOnlineDebug testOfflineDebug`
- [x] Check formatting: `./gradlew --init-script gradle/init.gradle.kts spotlessApply`
