### PR TITLE
fix: 修复升级compose-bom导致的应用打开闪退问题

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -331,6 +331,8 @@ androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscree
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidx-compose-bom" }
 androidx-compose-animation = { group = "androidx.compose.animation", name = "animation" }
 androidx-compose-animation-core = { group = "androidx.compose.animation", name = "animation-core" }
+androidx-compose-animation-android = { group = "androidx.compose.animation", name = "animation-android" }
+androidx-3compose-animation-core-android = { group = "androidx.compose.animation", name = "animation-core-android" }
 androidx-compose-animation-graphics = { group = "androidx.compose.animation", name = "animation-graphics" }
 androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation" }
 androidx-compose-foundation-layout = { group = "androidx.compose.foundation", name = "foundation-layout" }
@@ -338,7 +340,8 @@ androidx-compose-material = { group = "androidx.compose.material", name = "mater
 androidx-compose-material-icons-core = { group = "androidx.compose.material", name = "material-icons-core" }
 androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 androidx-compose-material-ripple = { group = "androidx.compose.material", name = "material-ripple" }
-androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+# FIXME: compose bom 2024.01.00 版本中的 material3 版本异常，单独指定版本，后续 bom 版本升级修复此问题需恢复
+androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3", version = "1.2.0-rc01" }
 androidx-compose-material3-window-size = { group = "androidx.compose.material3", name = "material3-window-size-class" }
 androidx-compose-runtime = { group = "androidx.compose.runtime", name = "runtime" }
 androidx-compose-runtime-livedata = { group = "androidx.compose.runtime", name = "runtime-livedata" }


### PR DESCRIPTION
compose-bom升级到 2024.01.00，其中的 material3 版本为 1.1.2，此版本包含异常，单独指定 material3 版本为 1.2.0-rc01，待后续版本修复

Thanks for submitting a pull request. Please include the following information.

**What I have done and why**
Include a summary of what your pull request contains, and why you have made these changes.

Fixes #<issue_number_goes_here>

**Do tests pass?**
- [x] Run local tests on `OnlineDebug` and `OfflineDebug` variant: `./gradlew testOnlineDebug testOfflineDebug`
- [x] Check formatting: `./gradlew --init-script gradle/init.gradle.kts spotlessApply`
