### PR TITLE
ci: `Build`流水线添加dependencyGuard检查

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -45,6 +45,21 @@ jobs:
       - name: Check spotless
         run: ./gradlew spotlessCheck --init-script gradle/init.gradle.kts --no-configuration-cache
 
+        # Runs if previous job failed
+      - name: Generate new Dependency Guard baselines if verification failed and it's a PR
+        id: dependencyguard_baseline
+        if: steps.dependencyguard_verify.outcome == 'failure' && github.event_name == 'pull_request'
+        run: |
+          ./gradlew dependencyGuardBaseline
+
+      - name: Push new Dependency Guard baselines if available
+        uses: stefanzweifel/git-auto-commit-action@v5
+        if: steps.dependencyguard_baseline.outcome == 'success'
+        with:
+          file_pattern: '**/dependencies/*.txt'
+          disable_globbing: true
+          commit_message: "🤖 Updates baselines for Dependency Guard"
+
       - name: Run all local screenshot tests (Roborazzi)
         id: screenshotsverify
         continue-on-error: true

--- a/app-catalog/build.gradle.kts
+++ b/app-catalog/build.gradle.kts
@@ -50,3 +50,7 @@ dependencies {
 
     implementation(projects.repos.mpChartLib)
 }
+
+dependencyGuard {
+    configuration("releaseRuntimeClasspath")
+}


### PR DESCRIPTION
Thanks for submitting a pull request. Please include the following information.

**What I have done and why**
在 `Build` 流水线添加 `dependencyGuard` 检查，检查失败自动进行 `dependencyGuardBaseline` 并创建提交

**Do tests pass?**
- [x] Run local tests on `OnlineDebug` and `OfflineDebug` variant: `./gradlew testOnlineDebug testOfflineDebug`
- [x] Check formatting: `./gradlew --init-script gradle/init.gradle.kts spotlessApply`
