### PR TITLE
chore: 更改文字描述，转账时不使用目标资产和关联的资产这种模糊描述而是使用转入/转出

### DIFF
--- a/core/ui/src/main/res/values/strings_records.xml
+++ b/core/ui/src/main/res/values/strings_records.xml
@@ -53,6 +53,8 @@
     <string name="copied_to_clipboard">已复制到剪贴板</string>
     <string name="target_asset">目标资产</string>
     <string name="related_asset">关联的资产</string>
+    <string name="transfer_to_asset">转入的资产</string>
+    <string name="transfer_from_asset">转出的资产</string>
     <string name="related_record">关联的记录</string>
     <string name="related_record_display_format">关联%1$s条记录，总计%2$s</string>
     <string name="tags">标签</string>

--- a/feature/records/src/main/kotlin/cn/wj/android/cashbook/feature/records/screen/EditRecordScreen.kt
+++ b/feature/records/src/main/kotlin/cn/wj/android/cashbook/feature/records/screen/EditRecordScreen.kt
@@ -594,20 +594,21 @@ private fun EditRecordScaffoldContent(
                     ) {
                         // 目标资产
                         val hasAsset = uiState.assetText.isNotBlank()
+                        val isTransferring = selectedTypeCategory == RecordTypeCategoryEnum.TRANSFER
                         ElevatedFilterChip(
                             selected = hasAsset,
                             onClick = onAssetClick,
-                            label = { Text(text = stringResource(id = R.string.target_asset) + if (hasAsset) ":${uiState.assetText}" else "") },
+                            label = { Text(text = stringResource(id = if(isTransferring) R.string.transfer_from_asset else R.string.target_asset) + if (hasAsset) ":${uiState.assetText}" else "") },
                         )
 
-                        if (selectedTypeCategory == RecordTypeCategoryEnum.TRANSFER) {
+                        if (isTransferring) {
                             // 只有转账类型显示关联资产
                             val hasRelatedAsset =
                                 uiState.relatedAssetText.isNotBlank()
                             ElevatedFilterChip(
                                 selected = hasRelatedAsset,
                                 onClick = onRelatedAssetClick,
-                                label = { Text(text = stringResource(id = R.string.related_asset) + if (hasRelatedAsset) ":${uiState.relatedAssetText}" else "") },
+                                label = { Text(text = stringResource(id = R.string.transfer_to_asset) + if (hasRelatedAsset) ":${uiState.relatedAssetText}" else "") },
                             )
                         }
 


### PR DESCRIPTION
Thanks for submitting a pull request. Please include the following information.

**What I have done and why**
Include a summary of what your pull request contains, and why you have made these changes.

转账时不使用"目标资产"和"关联的资产"这种模糊描述, 而是使用"转出的资产"和"转入的资产"
这种纯文本更改不影响逻辑所以我没test

**Do tests pass?**
- [ ] Run local tests on `OnlineDebug` and `OfflineDebug` variant: `./gradlew testOnlineDebug testOfflineDebug`
- [ ] Check formatting: `./gradlew --init-script gradle/init.gradle.kts spotlessApply`
