### PR TITLE
feat: 编辑记录页面标签列表的二级类型在行间展开，同0.6.2之前的交互一致

### DIFF
--- a/core/design/src/main/kotlin/cn/wj/android/cashbook/core/design/component/CbVerticalGrid.kt
+++ b/core/design/src/main/kotlin/cn/wj/android/cashbook/core/design/component/CbVerticalGrid.kt
@@ -22,6 +22,10 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 
 /**
@@ -36,6 +40,31 @@ fun <T> CbVerticalGrid(
     modifier: Modifier = Modifier,
     content: @Composable (T) -> Unit,
 ) {
+    CbVerticalGridRowExpansion(
+        columns,
+        items,
+        modifier,
+        defaultExpandedIndex = null,
+        expandedRowContent = {},
+    ) { item, _ ->
+        content(item)
+    }
+}
+
+/**
+ * 横向网格布局，行之间可以嵌套自定义内容
+ *
+ */
+@Composable
+fun <T> CbVerticalGridRowExpansion(
+    columns: Int,
+    items: List<T>,
+    modifier: Modifier = Modifier,
+    defaultExpandedIndex: Int? = null,
+    expandedRowContent: @Composable (T) -> Unit = {},
+    content: @Composable (T, () -> Unit) -> Unit,
+) {
+    var curExpandedIdx by remember { mutableStateOf(defaultExpandedIndex) }
     Column(
         modifier = modifier,
     ) {
@@ -49,15 +78,22 @@ fun <T> CbVerticalGrid(
             }
             val columnCount = fixedSize / columns
             for (col in 0 until columnCount) {
+                var extend = false
                 Row(modifier = Modifier.fillMaxWidth()) {
                     for (r in 0 until columns) {
                         Box(modifier = Modifier.weight(1f)) {
                             val index = col * columns + r
                             if (index in items.indices) {
-                                content(items[index])
+                                if (curExpandedIdx == index) {
+                                    extend = true
+                                }
+                                content(items[index], { curExpandedIdx = index })
                             }
                         }
                     }
+                }
+                if (extend) {
+                    expandedRowContent(items[curExpandedIdx!!])
                 }
             }
         }

--- a/core/domain/src/main/kotlin/cn/wj/android/cashbook/domain/usecase/GetRecordTypeListUseCase.kt
+++ b/core/domain/src/main/kotlin/cn/wj/android/cashbook/domain/usecase/GetRecordTypeListUseCase.kt
@@ -54,7 +54,7 @@ class GetRecordTypeListUseCase @Inject constructor(
                 list.map { model ->
                     model.asEntity(
                         child = typeRepository.getSecondRecordTypeListByParentId(model.id)
-                            .map { it.asEntity() }
+                            .map { it.asEntity(selected = selectedTypeId == it.id) }
                             .sortedBy { it.sort },
                     )
                 }

--- a/core/model/src/main/kotlin/cn/wj/android/cashbook/core/model/transfer/ModelTransfer.kt
+++ b/core/model/src/main/kotlin/cn/wj/android/cashbook/core/model/transfer/ModelTransfer.kt
@@ -59,6 +59,7 @@ fun RecordEntity.asModel(): RecordModel {
 
 fun RecordTypeModel.asEntity(
     child: List<RecordTypeEntity> = emptyList(),
+    selected: Boolean = false,
 ): RecordTypeEntity {
     return RecordTypeEntity(
         id = this.id,
@@ -68,7 +69,7 @@ fun RecordTypeModel.asEntity(
         sort = this.sort,
         typeCategory = this.typeCategory,
         child = child,
-        selected = false,
+        selected = selected,
         shapeType = -1,
         needRelated = needRelated,
     )


### PR DESCRIPTION
Thanks for submitting a pull request. Please include the following information.

**What I have done and why**
Include a summary of what your pull request contains, and why you have made these changes.

feat: 编辑记录页面标签列表的二级类型在行间展开，同0.6.2之前的交互一致
新增、编辑记录时的类型选项父子级都排列在网格中，视觉上的分级与交互可能0.6.2之前的方案更好

**Do tests pass?**
- [x] Run local tests on `OnlineDebug` and `OfflineDebug` variant: `./gradlew testOnlineDebug testOfflineDebug`
- [x] Check formatting: `./gradlew --init-script gradle/init.gradle.kts spotlessApply`
