### PR TITLE
[ci|build]AGP9 follow-up 1/2：CI 第三方 action SHA pin + 移除 mvnrepository 无效源

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -68,7 +68,7 @@ jobs:
           ./gradlew dependencyGuardBaseline
 
       - name: Push new Dependency Guard baselines if available
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
         if: steps.dependencyguard_baseline.outcome == 'success'
         with:
           file_pattern: '**/dependencies/*.txt'
@@ -95,7 +95,7 @@ jobs:
           ./gradlew recordRoborazziDevDebug
 
       - name: Push new screenshots if available
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
         if: steps.screenshotsrecord.outcome == 'success'
         with:
           file_pattern: '*/*.png'
@@ -146,7 +146,7 @@ jobs:
 
     steps:
       - name: Delete unnecessary tools 🔧
-        uses: jlumbroso/free-disk-space@v1.3.1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           android: false # Don't remove Android tools
           tool-cache: true # Remove image tool cache - rm -rf "$AGENT_TOOLSDIRECTORY"
@@ -182,7 +182,7 @@ jobs:
           gradle-home-cache-cleanup: true
 
       - name: Build projects and run instrumentation tests
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2
         with:
           api-level: ${{ matrix.api-level }}
           arch: x86_64
@@ -211,7 +211,7 @@ jobs:
       - name: Display local test coverage (only API 30)
         if: matrix.api-level == 30
         id: jacoco
-        uses: madrapps/jacoco-report@v1.8.0
+        uses: madrapps/jacoco-report@e51ce1f46f7f8b5331593f935e59cbaf44b84920 # v1.8.0
         with:
           title: Combined test coverage report
           min-coverage-overall: 40

--- a/.github/workflows/PreRelease.yaml
+++ b/.github/workflows/PreRelease.yaml
@@ -51,8 +51,7 @@ jobs:
              -Pandroid.experimental.testOptions.managedDevices.maxConcurrentDevices=1
 
       - name: Android Sign
-        # You may pin to the exact commit or the version.
-        uses: Tlaster/android-sign@v1.2.2
+        uses: Tlaster/android-sign@1c5bf4b2fa309acb0c0ae0bf9379ab458f14d5b1 # v1.2.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BUILD_TOOLS_VERSION: "36.0.0"
@@ -87,9 +86,7 @@ jobs:
           prerelease: true
 
       - name: Upload Multiple Release Assets
-        # You may pin to the exact commit or the version.
-        # uses: NBTX/upload-release-assets@f68d1c91ca950f33ee35514883819c2bb053f487
-        uses: NBTX/upload-release-assets@v1
+        uses: NBTX/upload-release-assets@f68d1c91ca950f33ee35514883819c2bb053f487 # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TZ: Asia/Shanghai
@@ -100,8 +97,7 @@ jobs:
           targets: outputs/signed_apk/*.apk
 
       - name: Publish Release
-        # You may pin to the exact commit or the version.
-        uses: eregon/publish-release@v1.0.6
+        uses: eregon/publish-release@01df127f5e9a3c26935118e22e738d95b59d10ce # v1.0.6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TZ: Asia/Shanghai

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -52,8 +52,7 @@ jobs:
              -Pandroid.experimental.testOptions.managedDevices.maxConcurrentDevices=1
 
       - name: Android Sign
-        # You may pin to the exact commit or the version.
-        uses: Tlaster/android-sign@v1.2.2
+        uses: Tlaster/android-sign@1c5bf4b2fa309acb0c0ae0bf9379ab458f14d5b1 # v1.2.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BUILD_TOOLS_VERSION: "36.0.0"
@@ -88,9 +87,7 @@ jobs:
           prerelease: false
 
       - name: Upload Multiple Release Assets
-        # You may pin to the exact commit or the version.
-        # uses: NBTX/upload-release-assets@f68d1c91ca950f33ee35514883819c2bb053f487
-        uses: NBTX/upload-release-assets@v1
+        uses: NBTX/upload-release-assets@f68d1c91ca950f33ee35514883819c2bb053f487 # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TZ: Asia/Shanghai
@@ -101,8 +98,7 @@ jobs:
           targets: outputs/signed_apk/*.apk
 
       - name: Publish Release
-        # You may pin to the exact commit or the version.
-        uses: eregon/publish-release@v1.0.6
+        uses: eregon/publish-release@01df127f5e9a3c26935118e22e738d95b59d10ce # v1.0.6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TZ: Asia/Shanghai

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -18,8 +18,6 @@ pluginManagement {
     // 配置插件仓库
     repositories {
         maven { setUrl("https://repo1.maven.org/maven2") }
-        maven { setUrl("https://mvnrepository.com/repos/central") }
-        maven { setUrl("https://mvnrepository.com/repos/space-kotlin-dev") }
         maven { setUrl("https://maven.aliyun.com/repository/gradle-plugin") }
         maven { setUrl("https://maven.aliyun.com/repository/public") }
         maven { setUrl("https://maven.aliyun.com/repository/google") }
@@ -34,8 +32,6 @@ dependencyResolutionManagement {
     @Suppress("UnstableApiUsage")
     repositories {
         maven { setUrl("https://repo1.maven.org/maven2") }
-        maven { setUrl("https://mvnrepository.com/repos/central") }
-        maven { setUrl("https://mvnrepository.com/repos/space-kotlin-dev") }
         maven { setUrl("https://maven.aliyun.com/repository/public") }
         maven { setUrl("https://maven.aliyun.com/repository/google") }
         maven { setUrl("https://jitpack.io") }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,8 +5,6 @@ pluginManagement {
     // 配置插件仓库
     repositories {
         maven { setUrl("https://repo1.maven.org/maven2") }
-        maven { setUrl("https://mvnrepository.com/repos/central") }
-        maven { setUrl("https://mvnrepository.com/repos/space-kotlin-dev") }
         maven { setUrl("https://maven.aliyun.com/repository/gradle-plugin") }
         maven { setUrl("https://maven.aliyun.com/repository/public") }
         maven { setUrl("https://maven.aliyun.com/repository/google") }
@@ -22,8 +20,6 @@ dependencyResolutionManagement {
     // 配置三方依赖仓库
     repositories {
         maven { setUrl("https://repo1.maven.org/maven2") }
-        maven { setUrl("https://mvnrepository.com/repos/central") }
-        maven { setUrl("https://mvnrepository.com/repos/space-kotlin-dev") }
         maven { setUrl("https://maven.aliyun.com/repository/public") }
         maven { setUrl("https://maven.aliyun.com/repository/google") }
         maven { setUrl("https://jitpack.io") }


### PR DESCRIPTION
## AGP9 升级 follow-up（批次 1/2）

处理 AGP9 工具链升级遗留的 follow-up 技术债，本 PR 含两项**确定安全**的改动。

### #1 CI 第三方 action SHA pin（供应链加固）
把 7 个非官方 GitHub Action pin 到 commit SHA（保留版本注释便于追溯）：
`Tlaster/android-sign` `NBTX/upload-release-assets` `eregon/publish-release` `stefanzweifel/git-auto-commit-action` `jlumbroso/free-disk-space` `reactivecircus/android-emulator-runner` `madrapps/jacoco-report`。官方 `actions/*`、`gradle/*` 保留 tag（劫持风险低、tag 维护省心）。

### #2 移除 mvnrepository.com 无效 Maven 源
`settings.gradle.kts` + `build-logic/settings.gradle.kts` 中 `mvnrepository.com/repos/{central,space-kotlin-dev}` 实测返回 **HTTP 403 HTML 页**（非 Maven 端点），Gradle 请求同样 403、从未成功提供 artifact，移除为纯收益。`verification-metadata.xml` 仓库内不存在，无需处理。

### 本地验证
- 删源后 `help --configuration-cache --offline` store+reuse 均 BUILD SUCCESSFUL、**0 problem**，间接验证删源后配置阶段依赖解析正常。
- workflow YAML 结构未变（仅改 `uses:` 行 + 清理过时注释）。

### 其余 follow-up 处理
- **config-cache 开启**（执行阶段 CI 验证）→ 将单独开 PR。
- **baselineprofile 稳定版回退** → 上游无稳定版（`1.5.0-alpha06` 已是最新+唯一 AGP9 兼容），保持现状记技术债。
- **Release 签名链验证** → 合入后发 `_pre` tag 端到端验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
