### PR TITLE
[build]AGP9 follow-up：开启 configuration-cache（CI 验证执行阶段）

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,9 @@ org.gradle.configureondemand=false
 org.gradle.caching=true
 
 # Enable configuration caching between builds.
-org.gradle.configuration-cache=false
+# AGP9 升级 follow-up：配置阶段已本机评估（help --configuration-cache store+reuse）0 problem，
+# 开启让 CI 全 task（assemble/test/lint/androidTest）验证执行阶段兼容性。
+org.gradle.configuration-cache=true
 
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app"s APK


### PR DESCRIPTION
## AGP9 升级 follow-up：开启 configuration-cache（CI 验证）

承接 #492，本 PR **单独**验证 config-cache 开启的执行阶段兼容性，与那批 SHA pin/删源改动隔离、互不拖累。

### 改动
`org.gradle.configuration-cache=false → true`（仅 `gradle.properties` 一行 + 背景注释）。

### 配置阶段已本机评估通过
`help --configuration-cache --offline` store + reuse 均 `BUILD SUCCESSFUL`、**0 problem**（全部 convention plugin / KSP / Hilt / protobuf / spotless / baselineprofile 配置阶段兼容）。

### 本 PR 目的：让 CI 全 task 验证**执行阶段**
配置阶段无障碍，但执行阶段（自定义 `GenerateFlavorTask` / KSP / Roborazzi / `connectedDevDebugAndroidTest` 等高风险点）本机无法充分验证，由 CI 做权威评估：
- ✅ CI 全绿 → 执行阶段也兼容，合并保留开启。
- ❌ CI 红 → 记录失败 task，关闭本 PR、保持 `false`。

> `spotlessCheck` 在 `Build.yaml` 已显式 `--no-configuration-cache` 豁免，不受影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
