### PR TITLE
[build]AGP9 follow-up：config-cache 兼容化修复 + 开启

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -248,13 +248,16 @@ dependencyGuard {
 
 /** 配置 CI 构建生成 RELEASE.md（仅 BUILD_TAG_NAME 设置时；不依赖变体，AGP9 移除变体 API 后改普通 task + preBuild.dependsOn） */
 fun Project.configGenerateReleaseFile() {
+    // config-cache：执行阶段(doLast)不可访问 Task.project，配置阶段捕获所需值
+    val rootDirFile = rootDir
+    val projectName = name
     val generateReleaseFile = tasks.register("generateReleaseFile") {
         doLast {
             val buildTagName = System.getenv("BUILD_TAG_NAME")
             if (!buildTagName.isNullOrBlank()) {
                 // CI 构建流程，生成 RELEASE.md
-                File(rootDir, "CHANGELOG.md").readText().lines().let { list ->
-                    println("> Task :${project.name}:beforeMergeAssets generate RELEASE.md")
+                File(rootDirFile, "CHANGELOG.md").readText().lines().let { list ->
+                    println("> Task :$projectName:beforeMergeAssets generate RELEASE.md")
                     val start = if (buildTagName.endsWith("_pre")) {
                         // 预发布版本，使用 [Unreleased] 作为发布说明
                         list.indexOf("## [Unreleased]")
@@ -280,8 +283,8 @@ fun Project.configGenerateReleaseFile() {
                         }
                         toString()
                     }
-                    println("> Task :${project.name}:beforeMergeAssets generate RELEASE.md content = <$content>")
-                    val releaseFile = File(rootDir, "RELEASE.md")
+                    println("> Task :$projectName:beforeMergeAssets generate RELEASE.md content = <$content>")
+                    val releaseFile = File(rootDirFile, "RELEASE.md")
                     if (releaseFile.exists()) {
                         releaseFile.delete()
                     }

--- a/build-logic/convention/src/main/kotlin/cn/wj/android/cashbook/buildlogic/Badging.kt
+++ b/build-logic/convention/src/main/kotlin/cn/wj/android/cashbook/buildlogic/Badging.kt
@@ -60,7 +60,8 @@ abstract class GenerateBadgingTask : DefaultTask() {
 
     @TaskAction
     fun taskAction() {
-        println("> Task :${project.name}:GenerateBadgingTask")
+        // config-cache：@TaskAction(执行阶段)不可访问 Task.project，去掉 project.name
+        println("> Task :GenerateBadgingTask")
         execOperations.exec {
             commandLine(
                 aapt2Executable.get().asFile.absolutePath,

--- a/build-logic/convention/src/main/kotlin/cn/wj/android/cashbook/buildlogic/Jacoco.kt
+++ b/build-logic/convention/src/main/kotlin/cn/wj/android/cashbook/buildlogic/Jacoco.kt
@@ -89,10 +89,11 @@ internal fun Project.configureJacoco(
                 )
 
                 executionData.setFrom(
-                    project.fileTree("$buildDir/outputs/unit_test_code_coverage/${variant.name}UnitTest")
+                    // config-cache：project.fileTree 持有 project 引用不可序列化，改用配置阶段捕获的 objectFactory.fileTree（与上方 classDirectories 一致）
+                    myObjFactory.fileTree().setDir("$buildDir/outputs/unit_test_code_coverage/${variant.name}UnitTest")
                         .matching { include("**/*.exec") },
 
-                    project.fileTree("$buildDir/outputs/code_coverage/${variant.name}AndroidTest")
+                    myObjFactory.fileTree().setDir("$buildDir/outputs/code_coverage/${variant.name}AndroidTest")
                         .matching { include("**/*.ec") },
                 )
             }

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -27,11 +27,14 @@ android {
 // 原实现挂在 libraryVariants.preBuild.doFirst（AGP 9 移除变体 API），改为普通 Copy task 并让 preBuild 依赖它。
 val copyLegalDocsToAssets by tasks.registering(Copy::class) {
     val intoDir = File(projectDir, "src/main/assets")
+    // config-cache：执行阶段(doFirst)不可访问 Task.project，配置阶段捕获所需值
+    val rootDirFile = rootDir
+    val projectName = project.name
     doFirst {
-        println("> Task :${project.name}:copyLegalDocsToAssets copy .md files from $rootDir into $intoDir")
-        delete(intoDir)
+        println("> Task :$projectName:copyLegalDocsToAssets copy .md files from $rootDirFile into $intoDir")
+        intoDir.deleteRecursively()
     }
-    from(rootDir) {
+    from(rootDirFile) {
         include("PRIVACY_POLICY.md", "CHANGELOG.md")
     }
     into(intoDir)

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,9 @@ org.gradle.configureondemand=false
 org.gradle.caching=true
 
 # Enable configuration caching between builds.
-org.gradle.configuration-cache=false
+# AGP9 follow-up：已修复 copyLegalDocsToAssets/generateReleaseFile/GenerateBadgingTask/Jacoco
+# 的执行阶段 Project 访问（doFirst/doLast/@TaskAction 改配置阶段捕获），开启 config-cache 提速。
+org.gradle.configuration-cache=true
 
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app"s APK


### PR DESCRIPTION
## AGP9 follow-up：config-cache 兼容化修复 + 开启

承接已关闭的 #493（config-cache 执行阶段不兼容诊断）。本 PR 修复诊断出的不兼容 task 并开启 config-cache。

### 修复（执行阶段访问 `Task.project` → 配置阶段捕获）
- **`core/data:copyLegalDocsToAssets`**（#493 CI 实证）：`doFirst` 的 `project.name`/`rootDir` 捕获 + `delete()`→`File.deleteRecursively()`
- **`app:generateReleaseFile`**（#493 CI 实证）：`doLast` 的 `rootDir`/`project.name` 捕获
- **`GenerateBadgingTask`**：`@TaskAction` 去 `project.name`（CI 不跑 badging，防御性）
- **`Jacoco`**：`executionData` 的 `project.fileTree`→`objectFactory.fileTree`（与同文件 `classDirectories` 已用写法对齐）

未改：`GenerateFlavorTask`/`CheckBadgingTask`/`PrintApkLocationTask`（已是纯 Property，兼容）；`Outputs` copyApk 的 `rename` lambda（评估倾向兼容——`renamer` 纯 lambda 不捕获 project，靠本 PR CI 验证）。

### 本机验证
- `copyLegalDocs`+`generateReleaseFile` config-cache store **0 problem**
- build-logic 编译通过 + 主项目 spotless 通过（含 build-logic Kotlin）

### 本 PR 目的：CI 全 task 验证执行阶段
config-cache 常"修一个暴露下一个"，本 PR 让 CI 全 task（assemble 含 release / test / lint / androidTest / coverage）验证。绿则保留开启；若暴露剩余点（如 Outputs copyApk），据日志续修。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
