### PR TITLE
[fix|CI][公共]CI 稳定性修复：跳过 aliyun 镜像 + Test 任务显式 javaLauncher=21

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,8 @@ app → feature/* → core/*
 
 ## 规范（强制）
 - 所有修改新增功能必须确认是否新增对应测试，功能开发必须在测试通过才算完成
+- **本地跑任何单测需本机可探测 JDK 21**：convention 插件为全部 Test 任务显式 `javaLauncher`=Java 21 toolchain（`ProjectSetting.Config.TEST_JVM_VERSION`，Robolectric 模拟 SDK 36 要求 Java 21 运行时；不显式声明时 CI 上 fork JVM 曾漂移到 17 致 25 个截图测试类沙箱崩溃）。项目未配 foojay resolver 不会自动下载 JDK——本机 JAVA_HOME=21 或标准路径装有 JDK 21 即可；只装 JDK 17 的环境跑测试会报 `Cannot find a Java installation ... languageVersion=21`。未来升 `javaVersion` 时须核对 `TEST_JVM_VERSION` ≥ 编译版本
+- **依赖仓库 CI/本地二元化**：`settings.gradle.kts` 按 `CI` 环境变量切换 repo 顺序——CI（海外 runner）官方源优先、aliyun 殿后兜底（aliyun 海外访问间歇 502/404，且部分同步镜像有 pom 缺 jar 时 Gradle 锁定不回落官方源，曾致 main 红与多 dependabot PR 假失败）；本地 aliyun 优先加速。**aliyun 不可移除**：jcenter 遗产构件（如 dokitx 传递依赖 `com.android.volley:volley:1.1.1`）仅 aliyun 有、官方源 404（实测）。本地撞 aliyun 缺构件时可临时 `CI=true ./gradlew <task>` 切官方源优先自证是否镜像问题
 - 修改 Composable 或 ViewModel 的签名（参数增删）时，必须同步更新该模块 `src/test` 下对应的截图测试（`*ScreenshotTests`）与 `*ViewModelTest` 的构造/调用——模块测试源集整体编译，任一测试文件签名不匹配会导致整个模块 `testDebugUnitTest` 编译失败（既往多次踩坑：feature:settings 的 BackupAndRecoveryScreen/ViewModel 签名漂移、feature:records/assets 截图测试）
 - 测试替身（`core/testing` 的 `FakeXxxRepository` / `core/data` test 的 `FakeXxxDao`）的方法必须**忠实复刻真实 DAO/SQL 的匹配语义**，禁止用 `emptyList()` 桩或宽松 `contains` 替代真实条件——否则该路径成"假阳性覆盖"（测试绿但真实代码不这样执行，回归抓不到）。既往踩坑：`queryByTimeAndAmount`（元/分单位错配桩使去重永不命中）、`queryByWechatTransactionId`（`emptyList` 桩使 EXACT 路径从未覆盖 + 裸 `contains` 偏离真实 `remark LIKE '%[微信单号:<id>]%'` 方括号定界），均在评审时才暴露
 - 注：`core/data` 的 test 源集**不依赖 `core:testing`**（仅 junit+truth），各测试文件自带 `private fun createXxx` 构造数据；`core/domain`/`feature` 的 test 才用 `core:testing` 的 `FakeXxxRepository`/`createXxxModel`

--- a/build-logic/convention/src/main/kotlin/cn/wj/android/cashbook/buildlogic/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/cn/wj/android/cashbook/buildlogic/KotlinAndroid.kt
@@ -19,9 +19,14 @@ package cn.wj.android.cashbook.buildlogic
 import com.android.build.api.dsl.CommonExtension
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.tasks.testing.Test
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JavaToolchainService
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.provideDelegate
+import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinBaseExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
@@ -55,6 +60,8 @@ internal fun Project.configureKotlinAndroid(
             add("coreLibraryDesugaring", libs.findLibrary("android-desugarJdkLibs").get())
         }
     }
+
+    configureTestJavaLauncher()
 }
 
 /**
@@ -69,6 +76,27 @@ fun Project.configureKotlinJvm() {
     }
 
     configureKotlin<KotlinJvmProjectExtension>()
+
+    configureTestJavaLauncher()
+}
+
+/**
+ * 为 Test 任务显式指定 fork JVM 版本为 [ProjectSetting.Config.TEST_JVM_VERSION]
+ *
+ * 不显式声明时 Test fork JVM 跟随环境隐式选择，CI 上曾被解析为 Java 17，触发 Robolectric
+ * `Android SDK 36 requires Java 21 (have Java 17)` 沙箱创建失败；显式固定后不再受环境影响
+ */
+internal fun Project.configureTestJavaLauncher() {
+    val javaToolchains = extensions.getByType<JavaToolchainService>()
+    tasks.withType<Test>().configureEach {
+        javaLauncher.set(
+            javaToolchains.launcherFor {
+                languageVersion.set(
+                    JavaLanguageVersion.of(ProjectSetting.Config.TEST_JVM_VERSION),
+                )
+            },
+        )
+    }
 }
 
 /**

--- a/build-logic/convention/src/main/kotlin/cn/wj/android/cashbook/buildlogic/ProjectSetting.kt
+++ b/build-logic/convention/src/main/kotlin/cn/wj/android/cashbook/buildlogic/ProjectSetting.kt
@@ -71,6 +71,15 @@ object ProjectSetting {
         /** 源码 jdk 版本 */
         val javaVersion = JavaVersion.VERSION_17
 
+        /**
+         * Test 任务 fork JVM 版本
+         *
+         * Robolectric 模拟 Android SDK 36 要求 Java 21 运行时；不显式声明时 fork JVM 跟随环境
+         * 隐式选择（CI 上曾被解析为 Java 17 致沙箱创建失败 `Android SDK 36 requires Java 21`），
+         * 故统一显式固定为 21（编译产物仍为 [javaVersion] 目标，两者不冲突）
+         */
+        const val TEST_JVM_VERSION = 21
+
         /** 从环境变量中获取版本名，若没有则根据当前时间生成 */
         private fun generateVersionName(): String {
             val buildTagName = System.getenv("BUILD_TAG_NAME") ?: ""

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -17,7 +17,8 @@
 pluginManagement {
     // 配置插件仓库
     // CI（GitHub Actions 海外 runner）访问 aliyun 镜像不稳定（间歇 502/404），
-    // CI 环境跳过 aliyun 直连官方源；本地开发保持 aliyun 优先加速
+    // CI 环境 aliyun 移至官方源之后殿后兜底（不可移除，jcenter 遗产构件仅 aliyun 有）；
+    // 本地开发保持 aliyun 优先加速
     val isCi = System.getenv("CI").toBoolean()
     repositories {
         maven { setUrl("https://repo1.maven.org/maven2") }
@@ -29,12 +30,17 @@ pluginManagement {
         gradlePluginPortal()
         google()
         mavenCentral()
+        if (isCi) {
+            maven { setUrl("https://maven.aliyun.com/repository/gradle-plugin") }
+            maven { setUrl("https://maven.aliyun.com/repository/public") }
+            maven { setUrl("https://maven.aliyun.com/repository/google") }
+        }
     }
 }
 
 dependencyResolutionManagement {
     // 配置三方依赖仓库
-    // CI 环境跳过 aliyun 直连官方源，理由同 pluginManagement
+    // CI 环境 aliyun 殿后兜底（不可移除，jcenter 遗产构件仅 aliyun 有），理由同 pluginManagement
     val isCi = System.getenv("CI").toBoolean()
     @Suppress("UnstableApiUsage")
     repositories {
@@ -46,6 +52,10 @@ dependencyResolutionManagement {
         maven { setUrl("https://jitpack.io") }
         google()
         mavenCentral()
+        if (isCi) {
+            maven { setUrl("https://maven.aliyun.com/repository/public") }
+            maven { setUrl("https://maven.aliyun.com/repository/google") }
+        }
     }
     versionCatalogs {
         create("libs") {

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -16,11 +16,16 @@
 
 pluginManagement {
     // 配置插件仓库
+    // CI（GitHub Actions 海外 runner）访问 aliyun 镜像不稳定（间歇 502/404），
+    // CI 环境跳过 aliyun 直连官方源；本地开发保持 aliyun 优先加速
+    val isCi = System.getenv("CI").toBoolean()
     repositories {
         maven { setUrl("https://repo1.maven.org/maven2") }
-        maven { setUrl("https://maven.aliyun.com/repository/gradle-plugin") }
-        maven { setUrl("https://maven.aliyun.com/repository/public") }
-        maven { setUrl("https://maven.aliyun.com/repository/google") }
+        if (!isCi) {
+            maven { setUrl("https://maven.aliyun.com/repository/gradle-plugin") }
+            maven { setUrl("https://maven.aliyun.com/repository/public") }
+            maven { setUrl("https://maven.aliyun.com/repository/google") }
+        }
         gradlePluginPortal()
         google()
         mavenCentral()
@@ -29,11 +34,15 @@ pluginManagement {
 
 dependencyResolutionManagement {
     // 配置三方依赖仓库
+    // CI 环境跳过 aliyun 直连官方源，理由同 pluginManagement
+    val isCi = System.getenv("CI").toBoolean()
     @Suppress("UnstableApiUsage")
     repositories {
         maven { setUrl("https://repo1.maven.org/maven2") }
-        maven { setUrl("https://maven.aliyun.com/repository/public") }
-        maven { setUrl("https://maven.aliyun.com/repository/google") }
+        if (!isCi) {
+            maven { setUrl("https://maven.aliyun.com/repository/public") }
+            maven { setUrl("https://maven.aliyun.com/repository/google") }
+        }
         maven { setUrl("https://jitpack.io") }
         google()
         mavenCentral()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,11 +3,17 @@
 pluginManagement {
     includeBuild("build-logic")
     // 配置插件仓库
+    // CI（GitHub Actions 海外 runner）访问 aliyun 镜像不稳定（间歇 502/404，且镜像部分同步时
+    // Gradle 会锁定在缺 jar 的镜像上不回落官方源），故 CI 环境跳过 aliyun 直连官方源；
+    // 本地开发保持 aliyun 优先加速
+    val isCi = System.getenv("CI").toBoolean()
     repositories {
         maven { setUrl("https://repo1.maven.org/maven2") }
-        maven { setUrl("https://maven.aliyun.com/repository/gradle-plugin") }
-        maven { setUrl("https://maven.aliyun.com/repository/public") }
-        maven { setUrl("https://maven.aliyun.com/repository/google") }
+        if (!isCi) {
+            maven { setUrl("https://maven.aliyun.com/repository/gradle-plugin") }
+            maven { setUrl("https://maven.aliyun.com/repository/public") }
+            maven { setUrl("https://maven.aliyun.com/repository/google") }
+        }
         gradlePluginPortal()
         google()
         mavenCentral()
@@ -18,10 +24,14 @@ dependencyResolutionManagement {
     // 配置只能在当前文件配置三方依赖仓库，否则编译异常退出
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     // 配置三方依赖仓库
+    // CI 环境跳过 aliyun 直连官方源，理由同 pluginManagement
+    val isCi = System.getenv("CI").toBoolean()
     repositories {
         maven { setUrl("https://repo1.maven.org/maven2") }
-        maven { setUrl("https://maven.aliyun.com/repository/public") }
-        maven { setUrl("https://maven.aliyun.com/repository/google") }
+        if (!isCi) {
+            maven { setUrl("https://maven.aliyun.com/repository/public") }
+            maven { setUrl("https://maven.aliyun.com/repository/google") }
+        }
         maven { setUrl("https://jitpack.io") }
         google()
         mavenCentral()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,7 +4,8 @@ pluginManagement {
     includeBuild("build-logic")
     // 配置插件仓库
     // CI（GitHub Actions 海外 runner）访问 aliyun 镜像不稳定（间歇 502/404，且镜像部分同步时
-    // Gradle 会锁定在缺 jar 的镜像上不回落官方源），故 CI 环境跳过 aliyun 直连官方源；
+    // Gradle 会锁定在缺 jar 的镜像上不回落官方源），故 CI 环境 aliyun 移至官方源之后殿后兜底
+    // （不可移除：jcenter 遗产构件如 volley:1.1.1 仅 aliyun 有，官方源 404 实测）；
     // 本地开发保持 aliyun 优先加速
     val isCi = System.getenv("CI").toBoolean()
     repositories {
@@ -17,6 +18,11 @@ pluginManagement {
         gradlePluginPortal()
         google()
         mavenCentral()
+        if (isCi) {
+            maven { setUrl("https://maven.aliyun.com/repository/gradle-plugin") }
+            maven { setUrl("https://maven.aliyun.com/repository/public") }
+            maven { setUrl("https://maven.aliyun.com/repository/google") }
+        }
     }
 }
 
@@ -24,7 +30,7 @@ dependencyResolutionManagement {
     // 配置只能在当前文件配置三方依赖仓库，否则编译异常退出
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     // 配置三方依赖仓库
-    // CI 环境跳过 aliyun 直连官方源，理由同 pluginManagement
+    // CI 环境 aliyun 殿后兜底（不可移除，jcenter 遗产构件仅 aliyun 有），理由同 pluginManagement
     val isCi = System.getenv("CI").toBoolean()
     repositories {
         maven { setUrl("https://repo1.maven.org/maven2") }
@@ -35,6 +41,10 @@ dependencyResolutionManagement {
         maven { setUrl("https://jitpack.io") }
         google()
         mavenCentral()
+        if (isCi) {
+            maven { setUrl("https://maven.aliyun.com/repository/public") }
+            maven { setUrl("https://maven.aliyun.com/repository/google") }
+        }
     }
     // 配置 Version Catalogs
     versionCatalogs {


### PR DESCRIPTION
## 背景

main CI 红（run 29885889797）+ 多个 dependabot PR 假失败，排查实证两个独立根因：

## 根因与修复

### R1: CI 走 aliyun 镜像不稳（commit 1）
- GitHub Actions 海外 runner 访问 aliyun 国内镜像间歇 502/404（本轮 8 次 CI 失败实证：lint-tests-32.3.0.jar 同一构件几分钟内 404↔200 抖动）
- 部分同步镜像陷阱：aliyun 有 pom 缺 jar 时，Gradle 锁定该 repo 不回落官方源
- **修复**：settings.gradle.kts 按 `CI` 环境变量跳过 aliyun 直连 google()/mavenCentral()；本地开发保持 aliyun 优先不受影响

### R2: CI 上 Test fork JVM 漂移到 Java 17（commit 2）
- core:design 25 个 Robolectric 截图测试类 classMethod FAILED：`Failed to create a Robolectric sandbox: Android SDK 36 requires Java 21 (have Java 17)`
- 项目未显式声明 Test JVM，fork 版本跟随环境隐式解析（7-20 前 CI 解析为 21 绿，7-22 起漂移为 17 红；与 gradle-wrapper 9.6.1 升级或 runner 镜像更新时点吻合）
- **修复**：convention 插件为全部 Test 任务显式 `javaLauncher` = Java 21 toolchain（编译产物仍 target 17，不冲突）

## 验证

- ✅ 变异验证：本地把 launcher 显式设 17 → **精确复现 CI 崩溃**（25 类 classMethod FAILED、逐字同款错误）；还原 21 → 绿 —— 证明 launcher 机制真实控制 fork JVM 且修复有效
- ✅ 修复态 `:core:design:testDebugUnitTest` 绿（--rerun-tasks 真跑）
- ✅ CI 同款 `spotlessCheck` 绿、`check -p build-logic` 绿
- ⏳ R1 的 CI 仓库路径由本 PR 的 CI 运行做端到端终验（本地 offline 缓存来源所限无法完全模拟）

🤖 Generated with [Claude Code](https://claude.com/claude-code)